### PR TITLE
feat: add zkvm_io injectable I/O module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -138,6 +138,16 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // zkvm_io — injectable I/O module for the zevm_stateless binary.
+    // Default: reads from stdin, writes to stdout (suitable for native builds).
+    // Override for zkVM builds:
+    //   exe.root_module.addImport("zkvm_io", your_io_module)
+    const zkvm_io_mod = b.createModule(.{
+        .root_source_file = b.path("src/zkvm_io.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const exe = b.addExecutable(.{
         .name = "zevm_stateless",
         .root_module = b.createModule(.{
@@ -166,6 +176,7 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("executor",       executor_mod);
     exe.root_module.addImport("rlp_decode",     rlp_decode_mod);
     exe.root_module.addImport("main_allocator", main_allocator_mod);
+    exe.root_module.addImport("zkvm_io",        zkvm_io_mod);
 
     // Link crypto libraries required by native_executor_transition (secp256k1, OpenSSL, blst, mcl)
     exe.addIncludePath(.{ .cwd_relative = crypto_include });

--- a/src/io.zig
+++ b/src/io.zig
@@ -12,6 +12,7 @@ const std        = @import("std");
 const input_mod  = @import("input");
 const rlp_decode = @import("rlp_decode");
 const json_mod   = @import("json.zig");
+const zkvm_io    = @import("zkvm_io");
 
 /// Deserialize a zevm-zisk binary StatelessInput from stdin.
 ///
@@ -22,16 +23,7 @@ const json_mod   = @import("json.zig");
 ///   [u64: keys_count]    [u64 len + key bytes]  ...
 ///   [u64: headers_count] [u64 len + header RLP bytes] ...
 pub fn fromStdin(allocator: std.mem.Allocator) !input_mod.StatelessInput {
-    // Read all of stdin.
-    const stdin = std.fs.File{ .handle = std.posix.STDIN_FILENO };
-    var list = std.ArrayListUnmanaged(u8){};
-    var chunk: [4096]u8 = undefined;
-    while (true) {
-        const n = try stdin.read(&chunk);
-        if (n == 0) break;
-        try list.appendSlice(allocator, chunk[0..n]);
-    }
-    const data = list.items;
+    const data = try zkvm_io.read_input(allocator);
 
     var pos: usize = 0;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,7 @@ const mpt         = @import("mpt");
 const db          = @import("db");
 const executor    = @import("executor");
 const alloc_mod   = @import("main_allocator");
+const zkvm_io     = @import("zkvm_io");
 
 pub fn main() void {
     run() catch |err| {
@@ -222,6 +223,22 @@ fn run() !void {
             std.debug.print("\nFAIL\n", .{});
             std.process.exit(1);
         }
+
+        // Emit a machine-readable JSON result line to stdout.
+        var out_buf: [512]u8 = undefined;
+        const out = try std.fmt.bufPrint(&out_buf,
+            "{{\"block\":{d},\"valid\":true," ++
+            "\"pre_state_root\":\"0x{x}\"," ++
+            "\"post_state_root\":\"0x{x}\"," ++
+            "\"receipts_root\":\"0x{x}\"}}\n",
+            .{
+                si.block.number,
+                proof_out.pre_state_root,
+                proof_out.post_state_root,
+                proof_out.receipts_root,
+            },
+        );
+        zkvm_io.write_output(out);
     }
 
     std.debug.print("\nOK\n", .{});

--- a/src/zkvm_io.zig
+++ b/src/zkvm_io.zig
@@ -1,0 +1,35 @@
+//! Native zkVM I/O implementation.
+//!
+//! read_input  — reads all private input bytes from stdin.
+//! write_output — writes public output bytes to stdout.
+//!
+//! Override at build time by injecting a different "zkvm_io" module:
+//!
+//!   exe.root_module.addImport("zkvm_io", your_module)
+//!
+//! The replacement module must export:
+//!   pub fn read_input(allocator: std.mem.Allocator) ![]const u8 { ... }
+//!   pub fn write_output(data: []const u8) void { ... }
+//!
+//! See zevm-stateless-zisk for an example that uses memory-mapped I/O.
+
+const std = @import("std");
+
+/// Read all private input bytes (stdin in native builds).
+pub fn read_input(allocator: std.mem.Allocator) ![]const u8 {
+    const stdin = std.fs.File{ .handle = std.posix.STDIN_FILENO };
+    var list = std.ArrayListUnmanaged(u8){};
+    var chunk: [4096]u8 = undefined;
+    while (true) {
+        const n = try stdin.read(&chunk);
+        if (n == 0) break;
+        try list.appendSlice(allocator, chunk[0..n]);
+    }
+    return list.items;
+}
+
+/// Write public output bytes (stdout in native builds).
+pub fn write_output(data: []const u8) void {
+    const stdout = std.fs.File{ .handle = std.posix.STDOUT_FILENO };
+    stdout.writeAll(data) catch {};
+}


### PR DESCRIPTION
## Summary

- Introduces a swappable `zkvm_io` named module following the same pattern as `main_allocator`
- Default native implementation reads private input from stdin, writes public output to stdout
- `zevm-stateless-zisk` can override by injecting a replacement module at build time (e.g. memory-mapped I/O)

## Changes

| File | Change |
|------|--------|
| `src/zkvm_io.zig` | New injectable module: `read_input(allocator) ![]const u8` + `write_output(data)` |
| `src/io.zig` | `fromStdin()` delegates stdin reading to `zkvm_io.read_input()` |
| `src/main.zig` | Emits a machine-readable JSON result line to stdout on success |
| `build.zig` | `zkvm_io_mod` wired into the exe alongside `main_allocator` |

## Output format

On success, a single JSON line is written to stdout:
```json
{"block":624,"valid":true,"pre_state_root":"0x...","post_state_root":"0x...","receipts_root":"0x..."}
```

All diagnostic logs continue to go to stderr, so stdout is clean for machine consumers (zkVM provers, stateless-executor service, etc.).

## Test plan

- [x] `zig build` compiles cleanly
- [x] `cat stateless_input_624.bin | ./zig-out/bin/zevm_stateless 2>/dev/null` emits the JSON line only
- [x] Full diagnostic output still visible on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new I/O abstraction for stdin/stdout and changes `zevm_stateless` to emit a machine-consumable JSON line on success, which can affect integrations that parse stdout/stderr. Core execution logic is unchanged, but I/O wiring and output format changes are behaviorally significant.
> 
> **Overview**
> Adds an injectable `zkvm_io` module (wired in `build.zig`) so `zevm_stateless` can swap its input/output mechanism at build time for zkVM environments.
> 
> Updates binary input parsing to read via `zkvm_io.read_input()` instead of directly reading stdin, and on successful execution emits a single JSON result line via `zkvm_io.write_output()` to keep stdout machine-readable while diagnostics remain on stderr.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c27ae2d08f259cc738ef496937dabdf869d7a2c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->