### PR TITLE
Perf: refactor input witness handling, use node hash index throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,7 @@ Phase 1  MPT proof verification
   OK     root = 0x79f54cce9fd251fcc39c727b5db2d0fa94f7b76782be5cdf8336bd5cae24e609
          81 node(s) in pool, 117 key(s) verified
 
-Phase 2  WitnessDatabase queries
-  0xf93ee4cf...  nonce=0  balance=1000...  type=EOA  code_hash=0xc5d246...  storage_root=0x56e81f...
-  0x0000f908...  nonce=1  balance=0        type=contract  code_hash=0x6e49e6...  storage_root=0x56e81f...
-  ...
-
-Phase 3  Block execution
+Phase 2  Block execution
   block env
     number      = 1
     coinbase    = 0x8943545177806ed17b9f23f0a21ee5948ecaa776

--- a/src/executor/main.zig
+++ b/src/executor/main.zig
@@ -1,12 +1,15 @@
 //! BlockExecutor: stateless EVM block execution using zevm.
 //!
-//! Steps:
-//!   1. Verify the state witness (MPT proofs).
-//!   2. Build pre_alloc from the proven witness keys.
-//!   3. Build block-hash table and Env from the block header.
-//!   4. Detect the mainnet fork, decode transactions, execute via transition().
-//!   5. Compute the post-state root and receipts root.
-//!   6. Return a ProofOutput for the guest to commit.
+//! Caller is responsible for:
+//!   - Building the NodeIndex from witness nodes (mpt.buildNodeIndex)
+//!   - Verifying proofs and constructing pre_alloc from the witness
+//!   - Decoding block_hashes from witness headers
+//!
+//! This function handles:
+//!   1. Fork detection and Env construction.
+//!   2. Transaction decoding and execution via transition().
+//!   3. Post-state root and receipts root computation.
+//!   4. Returning a ProofOutput for the guest to commit.
 
 const std = @import("std");
 const primitives = @import("primitives");
@@ -21,140 +24,31 @@ const fork_mod = @import("executor_fork");
 const tx_decode = @import("executor_tx_decode");
 const types = @import("executor_types");
 
+/// Re-export so callers can use these types without importing executor_types directly.
+pub const BlockHashEntry = types.BlockHashEntry;
+pub const AllocAccount = types.AllocAccount;
+
 pub fn executeBlock(
     alloc: std.mem.Allocator,
-    stateless_input: input.StatelessInput,
+    pre_state_root: [32]u8,
+    pre_alloc: std.AutoHashMapUnmanaged(types.Address, types.AllocAccount),
+    index: *mpt.NodeIndex,
+    header: input.BlockHeader,
+    transactions: []const input.Transaction,
+    withdrawals: []const input.Withdrawal,
+    block_hashes: []types.BlockHashEntry,
     fork_name: ?[]const u8,
 ) !output.ProofOutput {
-    // 1. Verify witness proofs and obtain the pre-state root.
-    const pre_state_root = try mpt.verifyWitness(stateless_input.witness);
-
-    // 2. Build pre_alloc from witness keys.
-    var pre_alloc: std.AutoHashMapUnmanaged(types.Address, types.AllocAccount) = .{};
-    var current_addr: ?types.Address = null;
-
-    for (stateless_input.witness.keys) |key| {
-        if (key.len == 20) {
-            var addr: types.Address = undefined;
-            @memcpy(&addr, key[0..20]);
-            current_addr = addr;
-
-            const account_state = mpt.verifyAccount(
-                stateless_input.witness.state_root,
-                addr,
-                stateless_input.witness.nodes,
-            ) catch null orelse continue;
-
-            // Locate bytecode in the witness codes pool.
-            const code: []const u8 = blk: {
-                if (std.mem.eql(u8, &account_state.code_hash, &primitives.KECCAK_EMPTY)) {
-                    break :blk &.{};
-                }
-                for (stateless_input.witness.codes) |code_bytes| {
-                    const code_hash = mpt.keccak256(code_bytes);
-                    if (std.mem.eql(u8, &code_hash, &account_state.code_hash)) {
-                        break :blk code_bytes;
-                    }
-                }
-                break :blk &.{};
-            };
-
-            const entry = try pre_alloc.getOrPut(alloc, addr);
-            if (!entry.found_existing) {
-                entry.value_ptr.* = types.AllocAccount{
-                    .balance = account_state.balance,
-                    .nonce = account_state.nonce,
-                    .code = code,
-                    .pre_storage_root = account_state.storage_root,
-                };
-            }
-        } else if (key.len == 52) {
-            var addr: types.Address = undefined;
-            @memcpy(&addr, key[0..20]);
-            current_addr = addr;
-            var raw_slot: types.Hash = undefined;
-            @memcpy(&raw_slot, key[20..52]);
-
-            const acct_state = mpt.verifyAccount(
-                stateless_input.witness.state_root,
-                addr,
-                stateless_input.witness.nodes,
-            ) catch null orelse continue;
-
-            const value = mpt.verifyStorage(
-                acct_state.storage_root,
-                raw_slot,
-                stateless_input.witness.nodes,
-            ) catch 0;
-            if (value != 0) {
-                const entry = try pre_alloc.getOrPut(alloc, addr);
-                if (!entry.found_existing) entry.value_ptr.* = .{};
-                const slot_key = hashToU256(raw_slot);
-                try entry.value_ptr.*.storage.put(alloc, slot_key, value);
-            }
-        } else if (key.len == 32) {
-            if (current_addr) |addr| {
-                var raw_slot: types.Hash = undefined;
-                @memcpy(&raw_slot, key[0..32]);
-
-                const acct_state = mpt.verifyAccount(
-                    stateless_input.witness.state_root,
-                    addr,
-                    stateless_input.witness.nodes,
-                ) catch null orelse continue;
-
-                const value = mpt.verifyStorage(
-                    acct_state.storage_root,
-                    raw_slot,
-                    stateless_input.witness.nodes,
-                ) catch 0;
-                if (value != 0) {
-                    const entry = try pre_alloc.getOrPut(alloc, addr);
-                    if (!entry.found_existing) entry.value_ptr.* = .{};
-                    const slot_key = hashToU256(raw_slot);
-                    try entry.value_ptr.*.storage.put(alloc, slot_key, value);
-                }
-            }
-        }
-    }
-
-    // 3. Build block-hash table from witness headers.
-    var block_hashes = std.ArrayListUnmanaged(types.BlockHashEntry){};
-    for (stateless_input.witness.headers) |hdr_rlp| {
-        const hash = mpt.keccak256(hdr_rlp);
-        const outer = mpt.rlp.decodeItem(hdr_rlp) catch continue;
-        var hdr_rest = switch (outer.item) {
-            .list => |p| p,
-            .bytes => continue,
-        };
-        // Skip fields 0–7: parentHash, ommersHash, coinbase, stateRoot,
-        // txRoot, receiptsRoot, bloom (256 bytes), difficulty.
-        var skip: usize = 0;
-        while (skip < 8 and hdr_rest.len > 0) : (skip += 1) {
-            const fr = mpt.rlp.decodeItem(hdr_rest) catch break;
-            hdr_rest = hdr_rest[fr.consumed..];
-        }
-        if (hdr_rest.len == 0) continue;
-        // Field [8] = block number.
-        const num_r = mpt.rlp.decodeItem(hdr_rest) catch continue;
-        const num_bytes = switch (num_r.item) {
-            .bytes => |b| b,
-            .list => continue,
-        };
-        if (num_bytes.len > 8) continue;
-        var number: u64 = 0;
-        for (num_bytes) |b| number = (number << 8) | b;
-        try block_hashes.append(alloc, .{ .number = number, .hash = hash });
-    }
-
-    // 4. Build Env from the block header.
-    const header = stateless_input.block;
-    const spec = if (fork_name) |name| (fork_mod.specFromName(name) orelse fork_mod.mainnetSpec(header.number, header.timestamp)) else fork_mod.mainnetSpec(header.number, header.timestamp);
+    // 1. Detect fork and build Env.
+    const spec = if (fork_name) |name|
+        fork_mod.specFromName(name) orelse fork_mod.mainnetSpec(header.number, header.timestamp)
+    else
+        fork_mod.mainnetSpec(header.number, header.timestamp);
 
     // Map input.Withdrawal → types.Withdrawal.
-    const withdrawals = try alloc.alloc(types.Withdrawal, stateless_input.withdrawals.len);
-    for (stateless_input.withdrawals, 0..) |wd, i| {
-        withdrawals[i] = .{
+    const mapped_withdrawals = try alloc.alloc(types.Withdrawal, withdrawals.len);
+    for (withdrawals, 0..) |wd, i| {
+        mapped_withdrawals[i] = .{
             .index = wd.index,
             .validator_index = wd.validator_index,
             .address = wd.address,
@@ -173,12 +67,12 @@ pub fn executeBlock(
         .excess_blob_gas = header.excess_blob_gas,
         .parent_beacon_block_root = header.parent_beacon_block_root,
         .parent_hash = header.parent_hash,
-        .block_hashes = block_hashes.items,
-        .withdrawals = withdrawals,
+        .block_hashes = block_hashes,
+        .withdrawals = mapped_withdrawals,
     };
 
-    // 5. Map decoded transactions to TxInput and execute the block.
-    const txs = try tx_decode.decodeTxsFromInput(alloc, stateless_input.transactions);
+    // 2. Decode transactions and execute the block.
+    const txs = try tx_decode.decodeTxsFromInput(alloc, transactions);
     const result = try transition_mod.transition(
         alloc,
         pre_alloc,
@@ -189,8 +83,8 @@ pub fn executeBlock(
         fork_mod.blockReward(spec),
     );
 
-    // 6. Compute post-state and receipts roots.
-    const post_state_root = try output_mod.computeStateRootDelta(alloc, pre_state_root, result.alloc, stateless_input.witness.nodes);
+    // 3. Compute post-state and receipts roots.
+    const post_state_root = try output_mod.computeStateRootDelta(alloc, pre_state_root, result.alloc, index);
     const receipts_root = try output_mod.computeReceiptsRoot(alloc, result.receipts);
 
     // Map transition.Receipt → output.ReceiptData.
@@ -230,13 +124,4 @@ pub fn blockEnvFromHeader(header: input.BlockHeader) context.BlockEnv {
     );
 
     return block_env;
-}
-
-// ─── Private helpers ─────────────────────────────────────────────────────────
-
-/// Interpret a 32-byte big-endian hash as a u256 storage key.
-fn hashToU256(hash: types.Hash) u256 {
-    var result: u256 = 0;
-    for (hash) |b| result = (result << 8) | b;
-    return result;
 }

--- a/src/executor/output.zig
+++ b/src/executor/output.zig
@@ -73,7 +73,7 @@ pub fn computeReceiptsRoot(
 }
 
 /// stateRoot for stateless execution: applies account changes as MPT delta updates
-/// against `pre_state_root`, using `pool` (the witness node pool) to resolve existing nodes.
+/// against `pre_state_root`, using a pre-built NodeIndex for O(1) node lookups.
 ///
 /// This correctly handles a witness that only contains touched accounts — the untouched
 /// accounts remain implicit in the trie via their existing hash references.
@@ -81,11 +81,9 @@ pub fn computeStateRootDelta(
     alloc: std.mem.Allocator,
     pre_state_root: [32]u8,
     alloc_map: std.AutoHashMapUnmanaged(types.Address, types.AllocAccount),
-    pool: []const []const u8,
+    index: *mpt.NodeIndex,
 ) ![32]u8 {
     var state_root = pre_state_root;
-    var extra = std.ArrayListUnmanaged([]const u8){};
-    defer extra.deinit(alloc);
 
     var it = alloc_map.iterator();
     while (it.next()) |entry| {
@@ -93,7 +91,7 @@ pub fn computeStateRootDelta(
         const acct = entry.value_ptr.*;
         const addr_key = mpt_builder.keccak256(&addr);
 
-        const storage_root = try computeStorageRoot(alloc, acct, pool);
+        const storage_root = try computeStorageRootIndexed(alloc, acct, index);
         const code_hash: [32]u8 = if (acct.code.len > 0)
             mpt_builder.keccak256(acct.code)
         else
@@ -108,7 +106,7 @@ pub fn computeStateRootDelta(
         else
             try encodeAccountRlp(alloc, acct.nonce, acct.balance, storage_root, code_hash);
 
-        try mpt.updateAccountChained(alloc, &state_root, addr_key, account_rlp, pool, &extra);
+        try mpt.updateAccountChainedIndexed(alloc, &state_root, addr_key, account_rlp, index);
     }
     return state_root;
 }
@@ -146,29 +144,28 @@ pub fn computeStateRoot(
     return mpt_builder.trieRoot(alloc, items);
 }
 
-fn computeStorageRoot(
+/// Indexed storage root: delta-updates via pre-built NodeIndex (O(1) pool lookups),
+/// falling through to scratch-build when no pre_storage_root is set.
+fn computeStorageRootIndexed(
     alloc: std.mem.Allocator,
     account: types.AllocAccount,
-    pool: []const []const u8,
+    index: *mpt.NodeIndex,
 ) ![32]u8 {
     if (account.pre_storage_root) |old_root| {
-        // Delta mode: apply each touched slot as an update to the proven pre-state root.
-        // Zero-valued entries indicate deletions; non-zero entries are insertions/updates.
-        // Use updateStorageChained so that multiple updates on the same account work
-        // correctly: new intermediate nodes are accumulated in `extra` and reused by
-        // subsequent updates within the same account.
         var root = old_root;
-        var extra = std.ArrayListUnmanaged([]const u8){};
-        defer extra.deinit(alloc);
         var it = account.storage.iterator();
         while (it.next()) |entry| {
             var slot_key: [32]u8 = undefined;
             std.mem.writeInt(u256, &slot_key, entry.key_ptr.*, .big);
-            try mpt.updateStorageChained(alloc, &root, slot_key, entry.value_ptr.*, pool, &extra);
+            try mpt.updateStorageChainedIndexed(alloc, &root, slot_key, entry.value_ptr.*, index);
         }
         return root;
     }
-    // Scratch mode: build the storage trie from all non-zero slots.
+    return computeStorageRootScratch(alloc, account);
+}
+
+/// Scratch-build storage root from all non-zero slots (no witness pool needed).
+fn computeStorageRootScratch(alloc: std.mem.Allocator, account: types.AllocAccount) ![32]u8 {
     const storage = account.storage;
     const count = storage.count();
     if (count == 0) return mpt_builder.EMPTY_TRIE_HASH;
@@ -184,6 +181,27 @@ fn computeStorageRoot(
         i += 1;
     }
     return mpt_builder.trieRoot(alloc, items[0..i]);
+}
+
+/// Pool-based storage root: delta-updates via witness node pool (for legacy callers).
+fn computeStorageRoot(
+    alloc: std.mem.Allocator,
+    account: types.AllocAccount,
+    pool: []const []const u8,
+) ![32]u8 {
+    if (account.pre_storage_root) |old_root| {
+        var root = old_root;
+        var extra = std.ArrayListUnmanaged([]const u8){};
+        defer extra.deinit(alloc);
+        var it = account.storage.iterator();
+        while (it.next()) |entry| {
+            var slot_key: [32]u8 = undefined;
+            std.mem.writeInt(u256, &slot_key, entry.key_ptr.*, .big);
+            try mpt.updateStorageChained(alloc, &root, slot_key, entry.value_ptr.*, pool, &extra);
+        }
+        return root;
+    }
+    return computeStorageRootScratch(alloc, account);
 }
 
 fn encodeAccountRlp(

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,7 +6,6 @@ const rlp_decode = @import("rlp_decode");
 const input = @import("input");
 const primitives = @import("primitives");
 const mpt = @import("mpt");
-const db = @import("db");
 const executor = @import("executor");
 const alloc_mod = @import("main_allocator");
 const zkvm_io = @import("zkvm_io");
@@ -90,88 +89,120 @@ fn run() !void {
 
     std.debug.print("=== zevm-stateless: block #{d} ===\n\n", .{si.block.number});
 
-    // ── Phase 1: MPT proof verification ───────────────────────────────────────
-    std.debug.print("Phase 1  MPT proof verification\n", .{});
-    {
-        var phase1_ok = true;
-        var current_addr: ?primitives.Address = null;
-
-        for (si.witness.keys, 0..) |key, i| {
-            if (key.len == 20) {
-                var addr: primitives.Address = undefined;
-                @memcpy(&addr, key[0..20]);
-                current_addr = addr;
-
-                _ = mpt.verifyAccount(si.witness.state_root, addr, si.witness.nodes) catch |e| {
-                    std.debug.print("  [{d:>4}] FAIL account 0x{x} → {}\n", .{ i, addr, e });
-                    phase1_ok = false;
-                };
-            } else if (key.len == 52) {
-                var addr: primitives.Address = undefined;
-                @memcpy(&addr, key[0..20]);
-                current_addr = addr;
-                var slot: primitives.Hash = undefined;
-                @memcpy(&slot, key[20..52]);
-
-                const acct = mpt.verifyAccount(si.witness.state_root, addr, si.witness.nodes) catch |e| {
-                    std.debug.print("  [{d:>4}] FAIL account 0x{x} (storage) → {}\n", .{ i, addr, e });
-                    phase1_ok = false;
-                    continue;
-                };
-                if (acct) |a| {
-                    _ = mpt.verifyStorage(a.storage_root, slot, si.witness.nodes) catch |e| {
-                        std.debug.print("  [{d:>4}] FAIL storage 0x{x} slot=0x{x} → {}\n", .{ i, addr, slot, e });
-                        phase1_ok = false;
-                    };
-                }
-            } else if (key.len == 32) {
-                var slot: primitives.Hash = undefined;
-                @memcpy(&slot, key[0..32]);
-
-                if (current_addr) |addr| {
-                    const acct = mpt.verifyAccount(si.witness.state_root, addr, si.witness.nodes) catch |e| {
-                        std.debug.print("  [{d:>4}] FAIL account 0x{x} (storage) → {}\n", .{ i, addr, e });
-                        phase1_ok = false;
-                        continue;
-                    };
-                    if (acct) |a| {
-                        _ = mpt.verifyStorage(a.storage_root, slot, si.witness.nodes) catch |e| {
-                            std.debug.print("  [{d:>4}] FAIL storage 0x{x} slot=0x{x} → {}\n", .{ i, addr, slot, e });
-                            phase1_ok = false;
-                        };
-                    }
-                }
-            }
-        }
-
-        if (!phase1_ok) std.process.exit(1);
-    }
     std.debug.print(
-        "  OK     root = 0x{x}\n" ++
+        "witness  root = 0x{x}\n" ++
             "         {d} node(s), {d} code(s), {d} key(s), {d} header(s)\n\n",
         .{ si.witness.state_root, si.witness.nodes.len, si.witness.codes.len, si.witness.keys.len, si.witness.headers.len },
     );
 
-    // ── Phase 2: WitnessDatabase queries ──────────────────────────────────────
-    std.debug.print("Phase 2  WitnessDatabase queries\n", .{});
+    // ── Witness processing ────────────────────────────────────────────────────
+    // Build the NodeIndex once; it is also mutated by executeBlock during
+    // state-root delta computation (new intermediate nodes are inserted).
+    var node_index = try mpt.buildNodeIndex(allocator, si.witness.nodes);
+    defer node_index.deinit();
 
-    var account_count: usize = 0;
+    // Verify proof paths and populate the pre-execution account map in one pass.
+    const pre_state_root = si.witness.state_root;
+    var pre_alloc: std.AutoHashMapUnmanaged([20]u8, executor.AllocAccount) = .{};
+    var current_addr: ?[20]u8 = null;
+
     for (si.witness.keys) |key| {
-        if (key.len != 20) continue;
-        account_count += 1;
+        if (key.len == 20) {
+            var addr: [20]u8 = undefined;
+            @memcpy(&addr, key[0..20]);
+            current_addr = addr;
 
-        var addr: primitives.Address = undefined;
-        @memcpy(&addr, key[0..20]);
+            const account_state = (try mpt.verifyAccountIndexed(
+                si.witness.state_root,
+                addr,
+                &node_index,
+            )) orelse continue;
 
-        _ = mpt.verifyAccount(si.witness.state_root, addr, si.witness.nodes) catch |err| {
-            std.debug.print("  0x{x}  error: {}\n", .{ addr, err });
-        };
+            const code: []const u8 = blk: {
+                if (std.mem.eql(u8, &account_state.code_hash, &primitives.KECCAK_EMPTY)) break :blk &.{};
+                for (si.witness.codes) |code_bytes| {
+                    if (std.mem.eql(u8, &mpt.keccak256(code_bytes), &account_state.code_hash)) break :blk code_bytes;
+                }
+                break :blk &.{};
+            };
+
+            const entry = try pre_alloc.getOrPut(allocator, addr);
+            if (!entry.found_existing) {
+                entry.value_ptr.* = .{
+                    .balance = account_state.balance,
+                    .nonce = account_state.nonce,
+                    .code = code,
+                    .pre_storage_root = account_state.storage_root,
+                };
+            }
+        } else if (key.len == 52) {
+            var addr: [20]u8 = undefined;
+            @memcpy(&addr, key[0..20]);
+            current_addr = addr;
+            var raw_slot: [32]u8 = undefined;
+            @memcpy(&raw_slot, key[20..52]);
+
+            const acct_state = (try mpt.verifyAccountIndexed(
+                si.witness.state_root,
+                addr,
+                &node_index,
+            )) orelse continue;
+
+            const value = try mpt.verifyStorageIndexed(acct_state.storage_root, raw_slot, &node_index);
+            if (value != 0) {
+                const entry = try pre_alloc.getOrPut(allocator, addr);
+                if (!entry.found_existing) entry.value_ptr.* = .{};
+                try entry.value_ptr.*.storage.put(allocator, hashToU256(raw_slot), value);
+            }
+        } else if (key.len == 32) {
+            if (current_addr) |addr| {
+                var raw_slot: [32]u8 = undefined;
+                @memcpy(&raw_slot, key[0..32]);
+
+                const acct_state = (try mpt.verifyAccountIndexed(
+                    si.witness.state_root,
+                    addr,
+                    &node_index,
+                )) orelse continue;
+
+                const value = try mpt.verifyStorageIndexed(acct_state.storage_root, raw_slot, &node_index);
+                if (value != 0) {
+                    const entry = try pre_alloc.getOrPut(allocator, addr);
+                    if (!entry.found_existing) entry.value_ptr.* = .{};
+                    try entry.value_ptr.*.storage.put(allocator, hashToU256(raw_slot), value);
+                }
+            }
+        }
     }
 
-    std.debug.print("  {d} account(s) in witness\n\n", .{account_count});
+    // Decode block-hash table from witness headers.
+    var block_hashes = std.ArrayListUnmanaged(executor.BlockHashEntry){};
+    for (si.witness.headers) |hdr_rlp| {
+        const hash = mpt.keccak256(hdr_rlp);
+        const outer = mpt.rlp.decodeItem(hdr_rlp) catch continue;
+        var rest = switch (outer.item) {
+            .list => |p| p,
+            .bytes => continue,
+        };
+        var skip: usize = 0;
+        while (skip < 8 and rest.len > 0) : (skip += 1) {
+            const fr = mpt.rlp.decodeItem(rest) catch break;
+            rest = rest[fr.consumed..];
+        }
+        if (rest.len == 0) continue;
+        const num_r = mpt.rlp.decodeItem(rest) catch continue;
+        const num_bytes = switch (num_r.item) {
+            .bytes => |b| b,
+            .list => continue,
+        };
+        if (num_bytes.len > 8) continue;
+        var number: u64 = 0;
+        for (num_bytes) |b| number = (number << 8) | b;
+        try block_hashes.append(allocator, .{ .number = number, .hash = hash });
+    }
 
-    // ── Phase 3: Block execution ───────────────────────────────────────────────
-    std.debug.print("\nPhase 3  Block execution\n", .{});
+    // ── Block execution ───────────────────────────────────────────────────────
+    std.debug.print("Block execution\n", .{});
     {
         const block_env = executor.blockEnvFromHeader(si.block);
 
@@ -189,7 +220,17 @@ fn run() !void {
         std.debug.print("  transactions  = {d}\n", .{si.transactions.len});
         if (fork_name) |f| std.debug.print("  fork override = {s}\n", .{f});
 
-        const proof_out = executor.executeBlock(allocator, si, fork_name) catch |err| {
+        const proof_out = executor.executeBlock(
+            allocator,
+            pre_state_root,
+            pre_alloc,
+            &node_index,
+            si.block,
+            si.transactions,
+            si.withdrawals,
+            block_hashes.items,
+            fork_name,
+        ) catch |err| {
             std.debug.print("  FAIL → {}\n", .{err});
             std.process.exit(1);
         };
@@ -239,4 +280,10 @@ fn run() !void {
     }
 
     std.debug.print("\nOK\n", .{});
+}
+
+fn hashToU256(hash: [32]u8) u256 {
+    var result: u256 = 0;
+    for (hash) |b| result = (result << 8) | b;
+    return result;
 }

--- a/src/mpt/main.zig
+++ b/src/mpt/main.zig
@@ -648,6 +648,214 @@ pub fn updateStorageChained(
         keccak256(new_root_rlp);
 }
 
+// ─── Indexed variants of verifyWitness and chained update functions ────────────
+//
+// These accept a pre-built NodeIndex (hash→node map) produced by buildNodeIndex().
+// All pool lookups are O(1) hashmap lookups. New intermediate nodes created during
+// updates are inserted into the same index so subsequent lookups remain O(1).
+
+/// Like updateAccountChained but uses a mutable NodeIndex for O(1) lookups.
+/// New intermediate nodes are inserted into `index` so subsequent chained updates find them.
+pub fn updateAccountChainedIndexed(
+    alloc: std.mem.Allocator,
+    root: *[32]u8,
+    addr_key: [32]u8,
+    account_rlp: ?[]const u8,
+    index: *NodeIndex,
+) (MptError || error{OutOfMemory})!void {
+    var key_nibs: [64]u8 = undefined;
+    nibbles.bytesToNibbles(&addr_key, &key_nibs);
+
+    if (std.mem.eql(u8, root, &EMPTY_TRIE_HASH)) {
+        if (account_rlp) |val| {
+            const leaf_rlp = try updMakeLeaf(alloc, &key_nibs, val);
+            const h = keccak256(leaf_rlp);
+            try index.put(h, leaf_rlp);
+            root.* = h;
+        }
+        return;
+    }
+
+    const root_bytes = findNodeInIndex(index, root.*) orelse return error.InvalidProof;
+    const new_root_rlp = try updNodeExIndexed(alloc, root_bytes, &key_nibs, account_rlp, index);
+    root.* = if (new_root_rlp.len == 1 and new_root_rlp[0] == 0x80)
+        EMPTY_TRIE_HASH
+    else blk: {
+        const h = keccak256(new_root_rlp);
+        try index.put(h, new_root_rlp);
+        break :blk h;
+    };
+}
+
+/// Like updateStorageChained but uses a mutable NodeIndex for O(1) lookups.
+/// New intermediate nodes are inserted into `index` so subsequent chained updates find them.
+pub fn updateStorageChainedIndexed(
+    alloc: std.mem.Allocator,
+    root: *[32]u8,
+    slot: [32]u8,
+    new_value: u256,
+    index: *NodeIndex,
+) (MptError || error{OutOfMemory})!void {
+    const key_hash = keccak256(&slot);
+    var key_nibs: [64]u8 = undefined;
+    nibbles.bytesToNibbles(&key_hash, &key_nibs);
+
+    const new_val_enc: ?[]const u8 = if (new_value == 0) null else blk: {
+        break :blk try updRlpU256(alloc, new_value);
+    };
+
+    if (std.mem.eql(u8, root, &EMPTY_TRIE_HASH)) {
+        if (new_val_enc) |val| {
+            const leaf_rlp = try updMakeLeaf(alloc, &key_nibs, val);
+            const h = keccak256(leaf_rlp);
+            try index.put(h, leaf_rlp);
+            root.* = h;
+        }
+        return;
+    }
+
+    const root_bytes = findNodeInIndex(index, root.*) orelse return error.InvalidProof;
+    const new_root_rlp = try updNodeExIndexed(alloc, root_bytes, &key_nibs, new_val_enc, index);
+    root.* = if (new_root_rlp.len == 1 and new_root_rlp[0] == 0x80)
+        EMPTY_TRIE_HASH
+    else blk: {
+        const h = keccak256(new_root_rlp);
+        try index.put(h, new_root_rlp);
+        break :blk h;
+    };
+}
+
+/// Like updResolveRefEx but uses NodeIndex for O(1) lookups.
+/// New nodes created during updates are inserted into the same index, so a single lookup suffices.
+fn updResolveRefExIndexed(ref: node.NodeRef, index: *const NodeIndex) MptError![]const u8 {
+    return switch (ref) {
+        .empty => &.{0x80},
+        .hash => |h| findNodeInIndex(index, h) orelse return error.InvalidProof,
+        .inline_node => |b| b,
+    };
+}
+
+/// Like updNodeEx but uses a single mutable NodeIndex for O(1) pool lookups.
+/// New intermediate nodes are inserted into `index` so subsequent chained updates find them.
+fn updNodeExIndexed(
+    alloc: std.mem.Allocator,
+    node_rlp: []const u8,
+    remaining: []const u8,
+    new_val: ?[]const u8,
+    index: *NodeIndex,
+) (MptError || error{OutOfMemory})![]const u8 {
+    if (node_rlp.len == 1 and node_rlp[0] == 0x80) {
+        if (new_val) |val| return updMakeLeaf(alloc, remaining, val);
+        return alloc.dupe(u8, &.{0x80});
+    }
+
+    const decoded = node.decodeNode(node_rlp) catch |err| switch (err) {
+        error.InvalidRlp => return error.InvalidRlp,
+        error.InvalidNode => return error.InvalidNode,
+    };
+
+    switch (decoded) {
+        .branch => |b| {
+            if (remaining.len == 0) {
+                var enc: [16][]const u8 = undefined;
+                for (b.children, 0..) |child, i| enc[i] = try updRefEnc(alloc, child);
+                return updEncodeBranch(alloc, &enc, new_val orelse &.{});
+            }
+            const nib = remaining[0];
+            const child_rlp = try updResolveRefExIndexed(b.children[nib], index);
+            const new_child_rlp = try updNodeExIndexed(alloc, child_rlp, remaining[1..], new_val, index);
+            const new_child_enc = try updHashOrEmbedExIndexed(alloc, new_child_rlp, index);
+            var enc: [16][]const u8 = undefined;
+            for (b.children, 0..) |child, i| {
+                if (i == nib) enc[i] = new_child_enc else enc[i] = try updRefEnc(alloc, child);
+            }
+            return updEncodeBranch(alloc, &enc, b.value);
+        },
+
+        .extension => |e| {
+            var path_buf: [128]u8 = undefined;
+            const hp = nibbles.hpDecode(e.prefix, &path_buf) catch return error.InvalidHp;
+            if (hp.is_leaf) return error.InvalidNode;
+            const prefix = path_buf[0..hp.len];
+            const cp = nibbles.commonPrefixLen(prefix, remaining);
+
+            if (cp == prefix.len) {
+                const child_rlp = try updResolveRefExIndexed(e.child, index);
+                const new_child_rlp = try updNodeExIndexed(alloc, child_rlp, remaining[cp..], new_val, index);
+                if (new_child_rlp.len == 1 and new_child_rlp[0] == 0x80)
+                    return alloc.dupe(u8, &.{0x80});
+                const new_child_ref = try updHashOrEmbedExIndexed(alloc, new_child_rlp, index);
+                return updMakeExtension(alloc, prefix, new_child_ref);
+            }
+
+            var children_enc: [16][]const u8 = undefined;
+            for (&children_enc) |*enc| enc.* = try alloc.dupe(u8, &.{0x80});
+            var branch_val: []const u8 = &.{};
+
+            const old_nib = prefix[cp];
+            if (cp + 1 < prefix.len) {
+                const ext_rlp = try updMakeExtension(alloc, prefix[cp + 1 ..], try updRefEnc(alloc, e.child));
+                children_enc[old_nib] = try updHashOrEmbedExIndexed(alloc, ext_rlp, index);
+            } else {
+                children_enc[old_nib] = try updRefEnc(alloc, e.child);
+            }
+            if (new_val) |val| {
+                if (cp < remaining.len) {
+                    const new_nib = remaining[cp];
+                    const leaf_rlp = try updMakeLeaf(alloc, remaining[cp + 1 ..], val);
+                    children_enc[new_nib] = try updHashOrEmbedExIndexed(alloc, leaf_rlp, index);
+                } else {
+                    branch_val = val;
+                }
+            }
+            const branch_rlp = try updEncodeBranch(alloc, &children_enc, branch_val);
+            if (cp == 0) return branch_rlp;
+            const branch_ref = try updHashOrEmbedExIndexed(alloc, branch_rlp, index);
+            return updMakeExtension(alloc, prefix[0..cp], branch_ref);
+        },
+
+        .leaf => |lf| {
+            var path_buf: [128]u8 = undefined;
+            const hp = nibbles.hpDecode(lf.key_end, &path_buf) catch return error.InvalidHp;
+            if (!hp.is_leaf) return error.InvalidNode;
+            const suffix = path_buf[0..hp.len];
+            const cp = nibbles.commonPrefixLen(suffix, remaining);
+
+            if (cp == suffix.len and cp == remaining.len) {
+                if (new_val) |val| return updMakeLeaf(alloc, suffix, val);
+                return alloc.dupe(u8, &.{0x80});
+            }
+
+            if (new_val == null) {
+                return updMakeLeaf(alloc, suffix, lf.value);
+            }
+
+            var children_enc: [16][]const u8 = undefined;
+            for (&children_enc) |*enc| enc.* = try alloc.dupe(u8, &.{0x80});
+            var branch_val: []const u8 = &.{};
+
+            if (cp < suffix.len) {
+                const old_nib = suffix[cp];
+                const old_leaf_rlp = try updMakeLeaf(alloc, suffix[cp + 1 ..], lf.value);
+                children_enc[old_nib] = try updHashOrEmbedExIndexed(alloc, old_leaf_rlp, index);
+            } else {
+                branch_val = lf.value;
+            }
+            if (cp < remaining.len) {
+                const new_nib = remaining[cp];
+                const new_leaf_rlp = try updMakeLeaf(alloc, remaining[cp + 1 ..], new_val.?);
+                children_enc[new_nib] = try updHashOrEmbedExIndexed(alloc, new_leaf_rlp, index);
+            } else {
+                branch_val = new_val.?;
+            }
+            const branch_rlp = try updEncodeBranch(alloc, &children_enc, branch_val);
+            if (cp == 0) return branch_rlp;
+            const branch_ref = try updHashOrEmbedExIndexed(alloc, branch_rlp, index);
+            return updMakeExtension(alloc, suffix[0..cp], branch_ref);
+        },
+    }
+}
+
 /// Recursively update a node and return its new RLP bytes.
 /// Returns `&.{0x80}` (empty node) when the subtree becomes empty.
 fn updNode(
@@ -940,6 +1148,14 @@ fn updHashOrEmbedEx(alloc: std.mem.Allocator, node_rlp: []const u8, extra: *std.
     if (node_rlp.len < 32) return node_rlp;
     try extra.append(alloc, node_rlp);
     const h = keccak256(node_rlp);
+    return updRlpBytes(alloc, &h);
+}
+
+/// Like updHashOrEmbedEx but inserts the new node directly into the shared NodeIndex.
+fn updHashOrEmbedExIndexed(alloc: std.mem.Allocator, node_rlp: []const u8, index: *NodeIndex) ![]const u8 {
+    if (node_rlp.len < 32) return node_rlp;
+    const h = keccak256(node_rlp);
+    try index.put(h, node_rlp);
     return updRlpBytes(alloc, &h);
 }
 


### PR DESCRIPTION
TL/DR:
* make witness parsing & verification, alloc construction, and nodeIndex creation all on a single pass in src/main
* remove duplicate witness parsing in executeBlock, take as inputs
* use nodeIndex throughout, update index during storage updates

<img width="1186" height="429" alt="image" src="https://github.com/user-attachments/assets/706a960a-d791-4dfb-84c2-c51b68024db5" />

Using a node hash index during state root update substantially decereases the amount of keccak hashing.  During trie traversal (both verification and updates), the algorithm works by:
  1. Starting with a 32-byte root hash
  2. Looking up that hash → node bytes
  3. Decoding the node → child refs, each of which is either inline (< 32 bytes RLP, embedded directly) or a hash ref (≥ 32 bytes, stored as keccak256(child))
  4. Following hash refs by looking them up in the index

Another improvement is to limit the number of times we parse the witness in order to:
- build the trie
- build the node index
- build pre_alloc

This pr makes a clean split of concerns to prevents duplicate parsing :

  main.zig handles:
  - Build NodeIndex from witness nodes
  - Verify proofs + build pre_alloc in one pass
  - Build block_hashes from witness headers
  - Print diagnostic output

  executeBlock receives pre-cooked inputs:
  - pre_alloc (flat account map)
  - *NodeIndex (for state root delta)
  - pre_state_root
  - header, transactions, withdrawals, block_hashes
  - fork_name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core MPT proof/update and state-root delta computation, where subtle bugs can invalidate block verification. API refactors also change ownership/lifetimes of witness-derived inputs across the executor boundary.
> 
> **Overview**
> Moves witness handling responsibilities out of `executor.executeBlock`: callers now build a `NodeIndex`, verify proofs, assemble `pre_alloc`, and decode `block_hashes` up-front, then pass these into `executeBlock` alongside header/txs/withdrawals.
> 
> Switches post-state root computation to use a shared, mutable `NodeIndex` for **O(1) node lookups** during chained account/storage updates, adding indexed update helpers in `mpt` and updating `computeStateRootDelta`/storage-root logic accordingly (while keeping pool-based paths for legacy callers). Documentation/output text is updated to reflect the simplified phases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e04463946fb83861e1c4bce98377d397a53e9be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->