### PR TITLE
feat: clean input modes for zevm_stateless

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,51 @@ Stateless EVM block verifier in Zig. Verifies MPT proofs and executes blocks aga
 
 ## Quick start
 
+```bash
+zig build gen-example   # generate examples/block.json + examples/witness.json
+zig build run           # run against them (RLP from zkvm_io, default zkVM path)
+zig build test          # run all tests
+```
+
+## CLI usage
+
+```
+zevm_stateless [--fork F]                                    # RLP via zkvm_io (default / zkVM)
+zevm_stateless --ssz [--fork F]                              # SSZ via zkvm_io (stub)
+zevm_stateless --rlp <file> [--fork F]                       # RLP binary file
+zevm_stateless --ssz <file> [--fork F]                       # SSZ binary file (stub)
+zevm_stateless --json <block.json> <witness.json> [--fork F] # JSON files
+```
+
+- **No flag** — production zkVM path: reads binary RLP input from `zkvm_io.read_input()` (overridden by `zevm-stateless-zisk` to read from a memory region).
+- **`--rlp <file>`** — reads a binary RLP-encoded `StatelessInput` from a file (testing convenience).
+- **`--json <block> <witness>`** — parses two JSON files (testing convenience).
+- **`--ssz`** — SSZ support is a planned next step; currently returns a clear error.
+- **`--fork <name>`** — override the hardfork detection (e.g. `--fork Cancun`).
+
+Bare positional arguments without a format flag are an error.
+
 ## Synthetic example
 
 ```bash
-zig build gen-example   # generate examples/block.json + witness.json
-zig build run           # run against them
-zig build test          # run all tests
+zig build gen-example
+zig-out/bin/zevm_stateless --json examples/block.json examples/witness.json
 ```
 
 ## Test vectors
 
 ```bash
-zig build run-test-block
+zig-out/bin/zevm_stateless --json test/vectors/test_block.json test/vectors/test_block_witness.json
 ```
 
-Runs against `test/vectors/test_block.json` + `test/vectors/test_block_witness.json`
-(block #1, 100 transactions, 81 nodes, 106 accounts, 11 storage slots, 5 contracts).
+Runs against a mainnet-style block (block #1, 100 transactions, 81 nodes, 106 accounts, 11 storage slots, 5 contracts).
 
 ## Live node
 ```bash
 zig build
 ./run_proof.sh http://127.0.0.1:64393 1 # (endpoint, block number)
 ```
-`run_proof.sh` calls `debug_getRawBlock` and `debug_executionWitness` on the node, then runs the verifier.
+`run_proof.sh` calls `debug_getRawBlock` and `debug_executionWitness` on the node, writes temporary JSON files, then runs the verifier with `--json`.
 
 ## Output:
 
@@ -100,7 +122,7 @@ The script:
 1. Calls `debug_getRawBlock` to get the full RLP-encoded block.
 2. Calls `debug_generateWitness` (falls back to `debug_executionWitness`).
 3. Writes temporary `block.json` and `witness.json` files.
-4. Runs `zig-out/bin/zevm_stateless` on them (builds if not already built).
+4. Runs `zig-out/bin/zevm_stateless --json block.json witness.json` (builds if not already built).
 
 > **Note:** `debug_getRawBlock`, `debug_generateWitness` / `debug_executionWitness` are non-standard Geth debug methods. Most public RPC endpoints do not expose them.
 

--- a/build.zig
+++ b/build.zig
@@ -217,6 +217,7 @@ pub fn build(b: *std.Build) void {
     const run_test_block_cmd = b.addRunArtifact(exe);
     run_test_block_cmd.step.dependOn(b.getInstallStep());
     run_test_block_cmd.addArgs(&.{
+        "--json",
         "test/vectors/stateless/test_block.json",
         "test/vectors/stateless/test_block_witness.json",
     });

--- a/run_proof.sh
+++ b/run_proof.sh
@@ -12,7 +12,7 @@
 #   1. debug_getRawBlock      — to get the full RLP-encoded block
 #   2. debug_generateWitness  — to get the flat proof witness
 #      (falls back to debug_executionWitness if the first call returns an error)
-# Then runs: zig-out/bin/zevm_stateless <block.json> <witness.json>
+# Then runs: zig-out/bin/zevm_stateless --json <block.json> <witness.json>
 #
 # Requirements: curl, jq
 
@@ -133,4 +133,4 @@ if [ ! -f "$BINARY" ]; then
 fi
 
 echo ""
-exec "$BINARY" "$BLOCK_JSON" "$WITNESS_JSON"
+exec "$BINARY" --json "$BLOCK_JSON" "$WITNESS_JSON"

--- a/src/stateless/io.zig
+++ b/src/stateless/io.zig
@@ -1,78 +1,31 @@
-//! Binary deserializer for the zevm-zisk StatelessInput format.
+//! Input loaders for zevm_stateless.
 //!
-//! Binary layout (all integers big-endian):
-//!
-//!   [u64: block_rlp_len] [block_rlp_bytes]   — raw Ethereum block RLP
-//!   ExecutionWitness:
-//!     state / codes / keys / headers: u64 count + [u64-len-prefixed byte slices]
-//!
-//! Returned slices point directly into the arena-owned stdin buffer (zero-copy).
+//! Each function reads bytes from a source (zkvm_io stream or file) and
+//! delegates format decoding to the appropriate format module (rlp.zig, ssz.zig, …).
 
 const std = @import("std");
 const input_mod = @import("input");
-const rlp_decode = @import("rlp_decode");
-const json_mod = @import("json.zig");
+const rlp = @import("rlp.zig");
 const zkvm_io = @import("zkvm_io");
 
-/// Deserialize a zevm-zisk binary StatelessInput from stdin.
-///
-/// The sender writes:
-///   [u64 big-endian: block_rlp_len] [raw block RLP bytes]
-///   [u64: state_count]   [u64 len + node bytes] ...
-///   [u64: codes_count]   [u64 len + code bytes] ...
-///   [u64: keys_count]    [u64 len + key bytes]  ...
-///   [u64: headers_count] [u64 len + header RLP bytes] ...
-pub fn fromStdin(allocator: std.mem.Allocator) !input_mod.StatelessInput {
+/// RLP from zkvm_io.read_input() — default / zkVM production path.
+pub fn fromRlpStream(allocator: std.mem.Allocator) !input_mod.StatelessInput {
     const data = try zkvm_io.read_input(allocator);
-
-    var pos: usize = 0;
-
-    // ── Block RLP ─────────────────────────────────────────────────────────────
-    if (pos + 8 > data.len) return error.UnexpectedEndOfInput;
-    const rlp_len: usize = @intCast(std.mem.readInt(u64, data[pos..][0..8], .big));
-    pos += 8;
-    if (pos + rlp_len > data.len) return error.UnexpectedEndOfInput;
-    const block_rlp = data[pos..][0..rlp_len];
-    pos += rlp_len;
-
-    const blk = try json_mod.parseBlockFromRlp(allocator, block_rlp);
-
-    // ── ExecutionWitness ──────────────────────────────────────────────────────
-    const nodes = try readSliceArray(allocator, data, &pos);
-    const codes = try readSliceArray(allocator, data, &pos);
-    const keys = try readSliceArray(allocator, data, &pos);
-    const headers = try readSliceArray(allocator, data, &pos);
-
-    var witness = input_mod.StateWitness{
-        .state_root = @splat(0),
-        .nodes = nodes,
-        .codes = codes,
-        .keys = keys,
-        .headers = headers,
-    };
-    witness.state_root = rlp_decode.findPreStateRoot(witness.headers, blk.header.number) orelse blk.header.state_root;
-
-    return input_mod.StatelessInput{
-        .block = blk.header,
-        .transactions = blk.transactions,
-        .witness = witness,
-        .withdrawals = blk.withdrawals,
-    };
+    return rlp.decode(allocator, data);
 }
 
-/// Read a u64-count array of u64-length-prefixed byte slices (zero-copy into `data`).
-fn readSliceArray(allocator: std.mem.Allocator, data: []const u8, pos: *usize) ![]const []const u8 {
-    if (pos.* + 8 > data.len) return error.UnexpectedEndOfInput;
-    const count: usize = @intCast(std.mem.readInt(u64, data[pos.*..][0..8], .big));
-    pos.* += 8;
-    const result = try allocator.alloc([]const u8, count);
-    for (0..count) |i| {
-        if (pos.* + 8 > data.len) return error.UnexpectedEndOfInput;
-        const len: usize = @intCast(std.mem.readInt(u64, data[pos.*..][0..8], .big));
-        pos.* += 8;
-        if (pos.* + len > data.len) return error.UnexpectedEndOfInput;
-        result[i] = data[pos.*..][0..len];
-        pos.* += len;
-    }
-    return result;
+/// RLP from a binary file — testing convenience.
+pub fn fromRlpFile(allocator: std.mem.Allocator, path: []const u8) !input_mod.StatelessInput {
+    const data = try std.fs.cwd().readFileAlloc(allocator, path, 256 << 20);
+    return rlp.decode(allocator, data);
+}
+
+/// SSZ from zkvm_io.read_input() — not yet implemented.
+pub fn fromSszStream(_: std.mem.Allocator) !input_mod.StatelessInput {
+    return error.SszNotImplemented;
+}
+
+/// SSZ from a binary file — not yet implemented.
+pub fn fromSszFile(_: std.mem.Allocator, _: []const u8) !input_mod.StatelessInput {
+    return error.SszNotImplemented;
 }

--- a/src/stateless/main.zig
+++ b/src/stateless/main.zig
@@ -300,6 +300,7 @@ fn loadFromJson(allocator: std.mem.Allocator, block_path: []const u8, witness_pa
         .block = parsed_block.header,
         .transactions = parsed_block.transactions,
         .witness = wit,
+        .withdrawals = parsed_block.withdrawals,
     };
 }
 

--- a/src/stateless/main.zig
+++ b/src/stateless/main.zig
@@ -10,80 +10,98 @@ const executor = @import("executor");
 const alloc_mod = @import("main_allocator");
 const zkvm_io = @import("zkvm_io");
 
+const InputSource = union(enum) {
+    rlp_stream, // default: zkvm_io.read_input()
+    ssz_stream, // --ssz (no file)
+    rlp_file: []const u8, // --rlp <file>
+    ssz_file: []const u8, // --ssz <file>
+    json: struct { block: []const u8, witness: []const u8 }, // --json <b> <w>
+};
+
 pub fn main() !void {
     const allocator = alloc_mod.get();
 
     const args = try std.process.argsAlloc(allocator);
 
-    // Parse flags and positional arguments.
-    // --fork <name> may appear anywhere; first two non-flag args are block/witness paths.
+    // ── Arg parsing ───────────────────────────────────────────────────────────
     var fork_name: ?[]const u8 = null;
-    var block_path: ?[]const u8 = null;
-    var witness_path: ?[]const u8 = null;
-    {
-        var arg_i: usize = 1;
-        while (arg_i < args.len) : (arg_i += 1) {
-            if (std.mem.eql(u8, args[arg_i], "--fork") and arg_i + 1 < args.len) {
-                arg_i += 1;
-                fork_name = args[arg_i];
-            } else if (block_path == null) {
-                block_path = args[arg_i];
-            } else if (witness_path == null) {
-                witness_path = args[arg_i];
+    var source: InputSource = .rlp_stream;
+
+    var arg_i: usize = 1;
+    while (arg_i < args.len) : (arg_i += 1) {
+        const arg = args[arg_i];
+
+        if (std.mem.eql(u8, arg, "--fork")) {
+            arg_i += 1;
+            if (arg_i >= args.len) {
+                std.debug.print("error: --fork requires a fork name\n", .{});
+                printUsage();
+                std.process.exit(1);
             }
+            fork_name = args[arg_i];
+        } else if (std.mem.eql(u8, arg, "--rlp")) {
+            arg_i += 1;
+            if (arg_i >= args.len or std.mem.startsWith(u8, args[arg_i], "--")) {
+                std.debug.print("error: --rlp requires a file path\n", .{});
+                printUsage();
+                std.process.exit(1);
+            }
+            source = .{ .rlp_file = args[arg_i] };
+        } else if (std.mem.eql(u8, arg, "--ssz")) {
+            // --ssz may optionally be followed by a file path
+            if (arg_i + 1 < args.len and !std.mem.startsWith(u8, args[arg_i + 1], "--")) {
+                arg_i += 1;
+                source = .{ .ssz_file = args[arg_i] };
+            } else {
+                source = .ssz_stream;
+            }
+        } else if (std.mem.eql(u8, arg, "--json")) {
+            arg_i += 1;
+            if (arg_i >= args.len) {
+                std.debug.print("error: --json requires block and witness paths\n", .{});
+                printUsage();
+                std.process.exit(1);
+            }
+            const block_path = args[arg_i];
+            arg_i += 1;
+            if (arg_i >= args.len) {
+                std.debug.print("error: --json requires block and witness paths\n", .{});
+                printUsage();
+                std.process.exit(1);
+            }
+            const witness_path = args[arg_i];
+            source = .{ .json = .{ .block = block_path, .witness = witness_path } };
+        } else {
+            std.debug.print("error: unexpected argument '{s}'\n", .{arg});
+            std.debug.print("hint:  use --json <block> <witness>, --rlp <file>, or --ssz [file]\n", .{});
+            printUsage();
+            std.process.exit(1);
         }
     }
 
-    const si: input.StatelessInput = if (block_path == null) blk: {
-        // No file paths — read binary StatelessInput from stdin (zevm-zisk format).
-        break :blk io.fromStdin(allocator) catch |err| {
-            std.debug.print("error: failed to parse stateless input from stdin: {}\n", .{err});
-            std.debug.print("hint:  pipe a zevm-zisk binary StatelessInput, or pass block/witness paths as args\n", .{});
+    // ── Load input ────────────────────────────────────────────────────────────
+    const si: input.StatelessInput = switch (source) {
+        .rlp_stream => io.fromRlpStream(allocator) catch |err| {
+            std.debug.print("error: failed to parse RLP from zkvm_io.read_input(): {}\n", .{err});
+            std.debug.print("hint:  pipe a zevm-zisk binary StatelessInput, or use --rlp/--json flags\n", .{});
             std.process.exit(1);
-        };
-    } else blk: {
-        const bp = block_path.?;
-        const wp = witness_path orelse {
-            std.debug.print("usage: zevm_stateless <block.json> <witness.json> [--fork <name>]\n", .{});
-            std.debug.print("       zevm_stateless  # reads binary StatelessInput from stdin\n", .{});
+        },
+        .ssz_stream => io.fromSszStream(allocator) catch |err| {
+            std.debug.print("error: SSZ input not yet implemented: {}\n", .{err});
             std.process.exit(1);
-        };
-
-        const block_json = std.fs.cwd().readFileAlloc(allocator, bp, 1 << 20) catch |err| {
-            std.debug.print("error: cannot read {s}: {}\n", .{ bp, err });
+        },
+        .rlp_file => |path| io.fromRlpFile(allocator, path) catch |err| {
+            std.debug.print("error: failed to parse RLP from '{s}': {}\n", .{ path, err });
             std.process.exit(1);
-        };
-
-        const witness_json = std.fs.cwd().readFileAlloc(allocator, wp, 64 << 20) catch |err| {
-            std.debug.print("error: cannot read {s}: {}\n", .{ wp, err });
+        },
+        .ssz_file => |path| io.fromSszFile(allocator, path) catch |err| {
+            std.debug.print("error: SSZ input not yet implemented (file: '{s}'): {}\n", .{ path, err });
             std.process.exit(1);
-        };
-
-        const parsed_block = json.parseBlockJson(allocator, block_json) catch |err| {
-            std.debug.print("error: failed to parse {s}: {}\n", .{ bp, err });
-            std.debug.print("  accepted formats:\n", .{});
-            std.debug.print("    {{\"result\":\"0x<rlp>\"}}  raw JSON-RPC response from debug_getRawBlock\n", .{});
-            std.debug.print("    {{\"block\": \"0x<rlp>\"}}  generated by `zig build gen-example`\n", .{});
+        },
+        .json => |p| loadFromJson(allocator, p.block, p.witness) catch |err| {
+            std.debug.print("error: failed to load JSON input: {}\n", .{err});
             std.process.exit(1);
-        };
-
-        var wit = json.parseWitnessJson(allocator, witness_json) catch |err| {
-            std.debug.print("error: failed to parse {s}: {}\n", .{ wp, err });
-            std.debug.print("  accepted formats:\n", .{});
-            std.debug.print("    {{\"state\":[...],\"codes\":[...],\"keys\":[...],\"headers\":[...]}}  direct\n", .{});
-            std.debug.print("    {{\"jsonrpc\":\"2.0\",\"result\":{{...}}}}  JSON-RPC envelope\n", .{});
-            std.process.exit(1);
-        };
-        // Use the parent block's state root as the proof anchor.
-        // The witness proves the PRE-execution state; parsed_block.header.state_root is the
-        // POST-execution state root and must not be used here.
-        wit.state_root = rlp_decode.findPreStateRoot(wit.headers, parsed_block.header.number) orelse parsed_block.header.state_root;
-
-        break :blk input.StatelessInput{
-            .block = parsed_block.header,
-            .transactions = parsed_block.transactions,
-            .witness = wit,
-        };
+        },
     };
 
     std.debug.print("=== zevm-stateless: block #{d} ===\n\n", .{si.block.number});
@@ -95,12 +113,9 @@ pub fn main() !void {
     );
 
     // ── Witness processing ────────────────────────────────────────────────────
-    // Build the NodeIndex once; it is also mutated by executeBlock during
-    // state-root delta computation (new intermediate nodes are inserted).
     var node_index = try mpt.buildNodeIndex(allocator, si.witness.nodes);
     defer node_index.deinit();
 
-    // Verify proof paths and populate the pre-execution account map in one pass.
     const pre_state_root = si.witness.state_root;
     var pre_alloc: std.AutoHashMapUnmanaged([20]u8, executor.AllocAccount) = .{};
     var current_addr: ?[20]u8 = null;
@@ -251,6 +266,53 @@ pub fn main() !void {
     zkvm_io.write_output(out);
 
     std.debug.print("\nOK\n", .{});
+}
+
+fn loadFromJson(allocator: std.mem.Allocator, block_path: []const u8, witness_path: []const u8) !input.StatelessInput {
+    const block_json = std.fs.cwd().readFileAlloc(allocator, block_path, 1 << 20) catch |err| {
+        std.debug.print("error: cannot read {s}: {}\n", .{ block_path, err });
+        return err;
+    };
+
+    const witness_json = std.fs.cwd().readFileAlloc(allocator, witness_path, 64 << 20) catch |err| {
+        std.debug.print("error: cannot read {s}: {}\n", .{ witness_path, err });
+        return err;
+    };
+
+    const parsed_block = json.parseBlockJson(allocator, block_json) catch |err| {
+        std.debug.print("error: failed to parse {s}: {}\n", .{ block_path, err });
+        std.debug.print("  accepted formats:\n", .{});
+        std.debug.print("    {{\"result\":\"0x<rlp>\"}}  raw JSON-RPC response from debug_getRawBlock\n", .{});
+        std.debug.print("    {{\"block\": \"0x<rlp>\"}}  generated by `zig build gen-example`\n", .{});
+        return err;
+    };
+
+    var wit = json.parseWitnessJson(allocator, witness_json) catch |err| {
+        std.debug.print("error: failed to parse {s}: {}\n", .{ witness_path, err });
+        std.debug.print("  accepted formats:\n", .{});
+        std.debug.print("    {{\"state\":[...],\"codes\":[...],\"keys\":[...],\"headers\":[...]}}  direct\n", .{});
+        std.debug.print("    {{\"jsonrpc\":\"2.0\",\"result\":{{...}}}}  JSON-RPC envelope\n", .{});
+        return err;
+    };
+    wit.state_root = rlp_decode.findPreStateRoot(wit.headers, parsed_block.header.number) orelse parsed_block.header.state_root;
+
+    return input.StatelessInput{
+        .block = parsed_block.header,
+        .transactions = parsed_block.transactions,
+        .witness = wit,
+    };
+}
+
+fn printUsage() void {
+    std.debug.print(
+        \\usage:
+        \\  zevm_stateless [--fork F]                              # RLP from zkvm_io (default / zkVM)
+        \\  zevm_stateless --ssz [--fork F]                        # SSZ from zkvm_io (stub)
+        \\  zevm_stateless --rlp <file> [--fork F]                 # RLP binary file
+        \\  zevm_stateless --ssz <file> [--fork F]                 # SSZ binary file (stub)
+        \\  zevm_stateless --json <block.json> <witness.json> [--fork F]
+        \\
+    , .{});
 }
 
 fn putStorageSlot(

--- a/src/stateless/main.zig
+++ b/src/stateless/main.zig
@@ -57,14 +57,14 @@ pub fn main() !void {
             }
         } else if (std.mem.eql(u8, arg, "--json")) {
             arg_i += 1;
-            if (arg_i >= args.len) {
+            if (arg_i >= args.len or std.mem.startsWith(u8, args[arg_i], "--")) {
                 std.debug.print("error: --json requires block and witness paths\n", .{});
                 printUsage();
                 std.process.exit(1);
             }
             const block_path = args[arg_i];
             arg_i += 1;
-            if (arg_i >= args.len) {
+            if (arg_i >= args.len or std.mem.startsWith(u8, args[arg_i], "--")) {
                 std.debug.print("error: --json requires block and witness paths\n", .{});
                 printUsage();
                 std.process.exit(1);

--- a/src/stateless/rlp.zig
+++ b/src/stateless/rlp.zig
@@ -1,0 +1,68 @@
+//! Binary deserializer for the zevm-zisk RLP StatelessInput format.
+//!
+//! Binary layout (all integers big-endian):
+//!
+//!   [u64: block_rlp_len] [block_rlp_bytes]   — raw Ethereum block RLP
+//!   ExecutionWitness:
+//!     state / codes / keys / headers: u64 count + [u64-len-prefixed byte slices]
+//!
+//! Returned slices point directly into the caller-owned buffer (zero-copy).
+
+const std = @import("std");
+const input_mod = @import("input");
+const rlp_decode = @import("rlp_decode");
+const json_mod = @import("json.zig");
+
+/// Decode a zevm-zisk binary RLP StatelessInput from raw bytes.
+pub fn decode(allocator: std.mem.Allocator, data: []const u8) !input_mod.StatelessInput {
+    var pos: usize = 0;
+
+    // ── Block RLP ─────────────────────────────────────────────────────────────
+    if (pos + 8 > data.len) return error.UnexpectedEndOfInput;
+    const rlp_len: usize = @intCast(std.mem.readInt(u64, data[pos..][0..8], .big));
+    pos += 8;
+    if (pos + rlp_len > data.len) return error.UnexpectedEndOfInput;
+    const block_rlp = data[pos..][0..rlp_len];
+    pos += rlp_len;
+
+    const blk = try json_mod.parseBlockFromRlp(allocator, block_rlp);
+
+    // ── ExecutionWitness ──────────────────────────────────────────────────────
+    const nodes = try readSliceArray(allocator, data, &pos);
+    const codes = try readSliceArray(allocator, data, &pos);
+    const keys = try readSliceArray(allocator, data, &pos);
+    const headers = try readSliceArray(allocator, data, &pos);
+
+    var witness = input_mod.StateWitness{
+        .state_root = @splat(0),
+        .nodes = nodes,
+        .codes = codes,
+        .keys = keys,
+        .headers = headers,
+    };
+    witness.state_root = rlp_decode.findPreStateRoot(witness.headers, blk.header.number) orelse blk.header.state_root;
+
+    return input_mod.StatelessInput{
+        .block = blk.header,
+        .transactions = blk.transactions,
+        .witness = witness,
+        .withdrawals = blk.withdrawals,
+    };
+}
+
+/// Read a u64-count array of u64-length-prefixed byte slices (zero-copy into `data`).
+fn readSliceArray(allocator: std.mem.Allocator, data: []const u8, pos: *usize) ![]const []const u8 {
+    if (pos.* + 8 > data.len) return error.UnexpectedEndOfInput;
+    const count: usize = @intCast(std.mem.readInt(u64, data[pos.*..][0..8], .big));
+    pos.* += 8;
+    const result = try allocator.alloc([]const u8, count);
+    for (0..count) |i| {
+        if (pos.* + 8 > data.len) return error.UnexpectedEndOfInput;
+        const len: usize = @intCast(std.mem.readInt(u64, data[pos.*..][0..8], .big));
+        pos.* += 8;
+        if (pos.* + len > data.len) return error.UnexpectedEndOfInput;
+        result[i] = data[pos.*..][0..len];
+        pos.* += len;
+    }
+    return result;
+}


### PR DESCRIPTION
## Summary

- Adds explicit `--rlp`, `--ssz`, and `--json` flags to `zevm_stateless`
- Default (no flags) remains RLP via `zkvm_io.read_input()` — backward-compatible zkVM production path
- Bare positional args are now a clear error with usage message
- Extracts RLP decode logic into `src/stateless/rlp.zig`, ready for `ssz.zig` alongside it

## CLI

```
zevm_stateless [--fork F]                                    # RLP via zkvm_io (default / zkVM)
zevm_stateless --ssz [--fork F]                              # SSZ via zkvm_io (stub)
zevm_stateless --rlp <file> [--fork F]                       # RLP binary file
zevm_stateless --ssz <file> [--fork F]                       # SSZ binary file (stub)
zevm_stateless --json <block.json> <witness.json> [--fork F] # JSON files
```

## Files changed

| File | Change |
|------|--------|
| `src/stateless/main.zig` | `InputSource` union; new arg parser; `loadInput` dispatch; `loadFromJson` helper |
| `src/stateless/io.zig` | Thin loader layer — reads bytes, delegates to format decoder |
| `src/stateless/rlp.zig` | Extracted RLP decode logic (new file) |
| `README.md` | Document all five input modes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `zevm_stateless` CLI semantics (positional args now rejected; scripts must pass `--json/--rlp`), which can break existing tooling, though execution/proof logic is largely untouched.
> 
> **Overview**
> **`zevm_stateless` now requires explicit input mode flags** via a new `InputSource` arg parser: default is RLP from `zkvm_io.read_input()`, `--rlp <file>` loads binary RLP from disk, `--json <block.json> <witness.json>` loads JSON, and `--ssz [file]` is a stub that errors; bare positional args are now treated as invalid with a usage message.
> 
> RLP binary decoding was extracted from `io.zig` into a new `src/stateless/rlp.zig`, with `io.zig` becoming a thin loader layer. Docs and tooling were updated accordingly (`README` examples/usage, `run_proof.sh` and `zig build run-test-block` now pass `--json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8607286718eaf160f992c25db486c70cc62f076. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->